### PR TITLE
Feat/create-dbml-to-json-table-schema-package

### DIFF
--- a/packages/dbml-to-json-table-schema/.gitignore
+++ b/packages/dbml-to-json-table-schema/.gitignore
@@ -1,0 +1,1 @@
+coverage/

--- a/packages/dbml-to-json-table-schema/jest.config.js
+++ b/packages/dbml-to-json-table-schema/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/packages/dbml-to-json-table-schema/package.json
+++ b/packages/dbml-to-json-table-schema/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "dbml-to-json-table-schema",
+  "version": "0.0.0",
+  "main": "src/index.js",
+  "types": "src/index.js",
+  "license": "MIT",
+  "scripts": {
+    "test": "jest --collectCoverage."
+  },
+  "dependencies": {
+    "@dbml/core": "^3.4.0",
+    "json-pick-keys": "^0.1.4"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.4.3"
+  }
+}

--- a/packages/dbml-to-json-table-schema/src/configs/pickerKeys.ts
+++ b/packages/dbml-to-json-table-schema/src/configs/pickerKeys.ts
@@ -1,0 +1,44 @@
+const defaultPickConfig: Record<string, 0 | 1> = {
+  // refs
+  "refs.name": 1,
+
+  // refs endpoints
+  "refs.endpoints.relation": 1,
+  "refs.endpoints.tableName": 1,
+  "refs.endpoints.fieldNames": 1,
+
+  // enums
+  "enums.name": 1,
+
+  // enums values
+  "enums.values.name": 1,
+  "enums.values.note": 1,
+
+  // tables
+  "tables.id": 1,
+  "tables.name": 1,
+  "tables.note": 1,
+
+  // tables fields
+  "tables.fields.name": 1,
+  "tables.fields.type.type_name": 1,
+  "tables.fields.pk": 1,
+  "tables.fields.unique": 1,
+  "tables.fields.note": 1,
+  "tables.fields.increment": 1,
+  "tables.fields.not_null": 1,
+  "tables.fields.dbdefault": 1,
+
+  // tables indexes
+  "tables.indexes.unique": 1,
+  "tables.indexes.type": 1,
+  "tables.indexes.pk": 1,
+  "tables.indexes.name": 1,
+  "tables.indexes.note": 1,
+
+  // tables indexes columns
+  "tables.indexes.columns.type": 1,
+  "tables.indexes.columns.value": 1,
+};
+
+export default defaultPickConfig;

--- a/packages/dbml-to-json-table-schema/src/index.ts
+++ b/packages/dbml-to-json-table-schema/src/index.ts
@@ -1,0 +1,13 @@
+import { Parser } from "@dbml/core";
+import pickKeys from "json-pick-keys";
+import defaultPickConfig from "./configs/pickerKeys";
+
+import type { JSONTableSchema } from "./types";
+
+export const parseDBMLToJSON = (
+  dbmlCode: string,
+  pickConfig: Record<string, 0 | 1> = defaultPickConfig
+): JSONTableSchema[] => {
+  const rawParsedSchema = Parser.parseDBMLToJSON(dbmlCode);
+  return pickKeys(rawParsedSchema, pickConfig);
+};

--- a/packages/dbml-to-json-table-schema/src/tests/data.ts
+++ b/packages/dbml-to-json-table-schema/src/tests/data.ts
@@ -1,0 +1,312 @@
+export const onlyTablesSchemaDBMLCode = `
+  Table follows {
+    id integer [primary key, not null, increment]
+    following_user_id integer
+    view integer [default: 0]
+  }
+`;
+
+export const onlyTablesSchemaJSON = {
+  refs: [],
+  enums: [],
+  tables: [
+    {
+      name: "follows",
+      fields: [
+        {
+          name: "id",
+          pk: true,
+          increment: true,
+          not_null: true,
+          type: {
+            type_name: "integer",
+          },
+        },
+        {
+          name: "following_user_id",
+          type: {
+            type_name: "integer",
+          },
+        },
+        {
+          name: "view",
+          type: {
+            type_name: "integer",
+          },
+          dbdefault: {
+            type: "number",
+            value: 0,
+          },
+        },
+      ],
+      indexes: [],
+    },
+  ],
+};
+
+export const withEnumDBMLCode = `
+  Enum status {
+    active
+    inactive
+  }
+
+  Table follows {
+    status status
+  }
+`;
+
+export const withEnumJSON = {
+  refs: [],
+  enums: [
+    {
+      name: "status",
+      values: [
+        {
+          name: "active",
+        },
+        {
+          name: "inactive",
+        },
+      ],
+    },
+  ],
+  tables: [
+    {
+      name: "follows",
+      fields: [
+        {
+          name: "status",
+          type: {
+            type_name: "status",
+          },
+        },
+      ],
+      indexes: [],
+    },
+  ],
+};
+
+export const withRelationsAndUniquenessDBMLCode = `
+  Table follows {
+    following_user_id integer
+    created_at timestamp 
+  }
+
+  Table users {
+    id integer [primary key]
+    email varchar [unique]
+  }
+
+  Ref: users.id < follows.following_user_id
+`;
+
+export const withRelationsAndUniquenessJSON = {
+  refs: [
+    {
+      name: null,
+      endpoints: [
+        {
+          relation: "1",
+          tableName: "users",
+          fieldNames: ["id"],
+        },
+        {
+          relation: "*",
+          tableName: "follows",
+          fieldNames: ["following_user_id"],
+        },
+      ],
+    },
+  ],
+  enums: [],
+  tables: [
+    {
+      name: "follows",
+      fields: [
+        {
+          name: "following_user_id",
+          type: {
+            type_name: "integer",
+          },
+        },
+        {
+          name: "created_at",
+          type: {
+            type_name: "timestamp",
+          },
+        },
+      ],
+      indexes: [],
+    },
+    {
+      name: "users",
+      fields: [
+        {
+          name: "id",
+          type: {
+            type_name: "integer",
+          },
+          pk: true,
+        },
+        {
+          name: "email",
+          type: {
+            type_name: "varchar",
+          },
+          unique: true,
+        },
+      ],
+      indexes: [],
+    },
+  ],
+};
+
+export const dbmlSchemaWithIndexes = `
+  Table bookings {
+    id integer
+    country varchar
+    booking_date date
+
+    indexes {
+        (id, country) [pk] // composite primary key
+        created_at [name: 'created_at_index', note: 'Date']
+        booking_date
+        (country, booking_date) [unique]
+        booking_date [type: hash]
+        (\`id*2\`)
+        (\`id*3\`,\`getdate()\`)
+        (\`id*3\`,id)
+    }
+  }
+`;
+
+export const withIndexesJSON = {
+  refs: [],
+  enums: [],
+  tables: [
+    {
+      name: "bookings",
+      fields: [
+        {
+          name: "id",
+          type: {
+            type_name: "integer",
+          },
+        },
+        {
+          name: "country",
+          type: {
+            type_name: "varchar",
+          },
+        },
+        {
+          name: "booking_date",
+          type: {
+            type_name: "date",
+          },
+        },
+      ],
+      indexes: [
+        {
+          pk: true,
+          columns: [
+            {
+              type: "column",
+              value: "id",
+            },
+            {
+              type: "column",
+              value: "country",
+            },
+          ],
+        },
+        {
+          name: "created_at_index",
+          note: {
+            value: "Date",
+            token: {
+              start: {
+                offset: 190,
+                line: 9,
+                column: 47,
+              },
+              end: {
+                offset: 202,
+                line: 9,
+                column: 59,
+              },
+            },
+          },
+          columns: [
+            {
+              type: "column",
+              value: "created_at",
+            },
+          ],
+        },
+        {
+          columns: [
+            {
+              type: "column",
+              value: "booking_date",
+            },
+          ],
+        },
+        {
+          unique: true,
+          columns: [
+            {
+              type: "column",
+              value: "country",
+            },
+            {
+              type: "column",
+              value: "booking_date",
+            },
+          ],
+        },
+        {
+          type: "hash",
+          columns: [
+            {
+              type: "column",
+              value: "booking_date",
+            },
+          ],
+        },
+        {
+          columns: [
+            {
+              type: "expression",
+              value: "id*2",
+            },
+          ],
+        },
+        {
+          columns: [
+            {
+              type: "expression",
+              value: "id*3",
+            },
+            {
+              type: "expression",
+              value: "getdate()",
+            },
+          ],
+        },
+        {
+          columns: [
+            {
+              type: "expression",
+              value: "id*3",
+            },
+            {
+              type: "column",
+              value: "id",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/dbml-to-json-table-schema/src/tests/parseDBMLToJSON.test.ts
+++ b/packages/dbml-to-json-table-schema/src/tests/parseDBMLToJSON.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "@jest/globals";
+import { parseDBMLToJSON } from "../index";
+import {
+  dbmlSchemaWithIndexes,
+  onlyTablesSchemaDBMLCode,
+  onlyTablesSchemaJSON,
+  withEnumDBMLCode,
+  withEnumJSON,
+  withIndexesJSON,
+  withRelationsAndUniquenessDBMLCode,
+  withRelationsAndUniquenessJSON,
+} from "./data";
+
+describe("transform dbml to json table schema", () => {
+  test("only tables", () => {
+    expect(parseDBMLToJSON(onlyTablesSchemaDBMLCode)).toEqual(
+      onlyTablesSchemaJSON
+    );
+  });
+
+  test("with enums", () => {
+    expect(parseDBMLToJSON(withEnumDBMLCode)).toEqual(withEnumJSON);
+  });
+
+  test("with relations", () => {
+    expect(parseDBMLToJSON(withRelationsAndUniquenessDBMLCode)).toEqual(
+      withRelationsAndUniquenessJSON
+    );
+  });
+
+  test("with indexes", () => {
+    expect(parseDBMLToJSON(dbmlSchemaWithIndexes)).toEqual(
+      withIndexesJSON
+    );
+  });
+});

--- a/packages/dbml-to-json-table-schema/src/types.ts
+++ b/packages/dbml-to-json-table-schema/src/types.ts
@@ -1,0 +1,41 @@
+import type Endpoint from "@dbml/core/types/model_structure/endpoint";
+import type Enum from "@dbml/core/types/model_structure/enum";
+import type Field from "@dbml/core/types/model_structure/field";
+import type IndexColumn from "@dbml/core/types/model_structure/indexColumn";
+import type Index from "@dbml/core/types/model_structure/indexes";
+import type Ref from "@dbml/core/types/model_structure/ref";
+import type Table from "@dbml/core/types/model_structure/table";
+
+export interface JSONTableSchema {
+  refs: JSONTableRef;
+  enums: JSONTableEnum[];
+  tables: JSONTableTable;
+}
+
+export interface JSONTableEnum extends Pick<Enum, "name" | "note"> {}
+
+export interface JSONTableRef extends Pick<Ref, "id" | "name"> {
+  endpoints: Pick<Endpoint, "relation" | "tableName" | "fieldNames">;
+}
+
+export interface JSONTableField
+  extends Pick<
+    Field,
+    "name" | "pk" | "unique" | "note" | "increment" | "not_null" | "dbdefault"
+  > {
+  type: { type_name: string };
+}
+
+export interface JSONTableIndexColumn
+  extends Pick<IndexColumn, "type" | "value"> {}
+
+export interface JSONTableIndex
+  extends Pick<Index, "unique" | "type" | "pk" | "name" | "note"> {
+  columns: JSONTableIndexColumn[];
+}
+
+export interface JSONTableTable
+  extends Pick<Table, "name" | "note" > {
+  fields: JSONTableField[];
+  indexes: JSONTableIndex[];
+}

--- a/packages/dbml-to-json-table-schema/tsconfig.json
+++ b/packages/dbml-to-json-table-schema/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "rootDir": "./",
+    "baseUrl": "./",
+    "paths": {},
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
Create a utility to transform dbml code into a json table object. The utility simply
selects a few fields json fields generated by the dbml parser