### PR TITLE
chore(visualizer): add caret for field detail box

### DIFF
--- a/packages/json-table-schema-visualizer/src/components/Column/Column.tsx
+++ b/packages/json-table-schema-visualizer/src/components/Column/Column.tsx
@@ -1,4 +1,5 @@
 import KonvaText from "../dumb/KonvaText";
+import FieldDetails from "../FieldDetails/FieldDetails";
 
 import ColumnWrapper from "./ColumnWrapper";
 
@@ -15,8 +16,10 @@ interface ColumnProps {
   tableName: string;
   type: string;
   isPrimaryKey?: boolean;
+  isEnum: boolean;
   relationalTables?: Set<string> | null;
   offsetY?: number;
+  note?: string;
 }
 
 const Column = ({
@@ -26,6 +29,8 @@ const Column = ({
   isPrimaryKey = false,
   offsetY,
   relationalTables,
+  isEnum,
+  note,
 }: ColumnProps) => {
   const theme = useTheme();
 
@@ -52,7 +57,7 @@ const Column = ({
       />
 
       <KonvaText
-        text={type}
+        text={isEnum ? `${type} 🅴` : type}
         align="right"
         width={TABLE_WIDTH}
         fill={typeTextColor}
@@ -61,6 +66,10 @@ const Column = ({
         fontSize={FONT_SIZES.md}
         height={COLUMN_HEIGHT}
       />
+
+      {note != null || isEnum ? (
+        <FieldDetails note={note ?? ""} enumName={type} />
+      ) : null}
     </ColumnWrapper>
   );
 };

--- a/packages/json-table-schema-visualizer/src/components/FieldDetails/EnumDetails.stories.tsx
+++ b/packages/json-table-schema-visualizer/src/components/FieldDetails/EnumDetails.stories.tsx
@@ -1,0 +1,29 @@
+import EnumDetails from "./EnumDetails";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+import EnumsProvider from "@/providers/EnumsProvider";
+import { exampleData } from "@/fake/fakeJsonTables";
+
+const meta: Meta = {
+  component: EnumDetails,
+  title: "components/EnumDetails",
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EnumDetails>;
+
+export const EnumDetailsStory: Story = {
+  render: (props) => (
+    <EnumsProvider enums={exampleData.enums}>
+      <EnumDetails {...props} />
+    </EnumsProvider>
+  ),
+  args: {
+    enumName: "status",
+  },
+  parameters: {
+    withKonvaWrapper: true,
+  },
+};

--- a/packages/json-table-schema-visualizer/src/components/FieldDetails/EnumDetails.tsx
+++ b/packages/json-table-schema-visualizer/src/components/FieldDetails/EnumDetails.tsx
@@ -1,0 +1,45 @@
+import { Group } from "react-konva";
+
+import KonvaText from "../dumb/KonvaText";
+
+import { useGetEnum } from "@/hooks/enums";
+import { useTheme } from "@/hooks/theme";
+import { computeTextSize } from "@/utils/computeTextSize";
+import { PADDINGS } from "@/constants/sizing";
+
+interface EnumDetailsProps {
+  enumName: string;
+  y?: number;
+}
+
+const enumTextSize = computeTextSize("Enum");
+
+const EnumDetails = ({ enumName, y }: EnumDetailsProps) => {
+  const enumObject = useGetEnum(enumName);
+  const theme = useTheme();
+
+  if (enumObject === undefined) {
+    return null;
+  }
+
+  const enumNameX = enumTextSize.width + PADDINGS.md;
+
+  return (
+    <Group y={y}>
+      <KonvaText fontStyle="bold" fill={theme.red} text="Enum" />
+
+      <KonvaText x={enumNameX} fill={theme.green} text={enumObject.name} />
+
+      {enumObject.values.map((item, index) => (
+        <KonvaText
+          key={item.name}
+          y={(index + 1) * enumTextSize.height}
+          text={`- ${item.name}`}
+          fill={theme.enumItem}
+        />
+      ))}
+    </Group>
+  );
+};
+
+export default EnumDetails;

--- a/packages/json-table-schema-visualizer/src/components/FieldDetails/FieldDetailWrapper.stories.tsx
+++ b/packages/json-table-schema-visualizer/src/components/FieldDetails/FieldDetailWrapper.stories.tsx
@@ -1,0 +1,33 @@
+import FieldDetailWrapper from "./FieldDetailWrapper";
+import FieldDetails from "./FieldDetails";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+import EnumsProvider from "@/providers/EnumsProvider";
+import { exampleData } from "@/fake/fakeJsonTables";
+
+const meta: Meta = {
+  component: FieldDetailWrapper,
+  title: "components/FieldDetailWrapper",
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FieldDetailWrapper>;
+
+export const FieldDetailWrapperStory: Story = {
+  render: (props) => <FieldDetailWrapper {...props} />,
+  args: {
+    children: (
+      <EnumsProvider enums={exampleData.enums}>
+        <FieldDetails
+          note="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+          enumName="status"
+        />
+      </EnumsProvider>
+    ),
+  },
+  parameters: {
+    withKonvaWrapper: true,
+  },
+};

--- a/packages/json-table-schema-visualizer/src/components/FieldDetails/FieldDetailWrapper.tsx
+++ b/packages/json-table-schema-visualizer/src/components/FieldDetails/FieldDetailWrapper.tsx
@@ -1,13 +1,17 @@
-import { Group, Rect } from "react-konva";
+import { Group, Line, Rect } from "react-konva";
 import { useState, type ReactNode } from "react";
 
 import { COLUMN_HEIGHT, PADDINGS, TABLE_WIDTH } from "@/constants/sizing";
+import { useTheme } from "@/hooks/theme";
+import { computeCaretPoints } from "@/utils/computeCaretPoints";
 
 interface FieldDetailWrapperProps {
   children: ReactNode;
 }
+
 const FieldDetailWrapper = ({ children }: FieldDetailWrapperProps) => {
   const [isDetailVisible, setIsDetailVisible] = useState(false);
+  const theme = useTheme();
 
   const handleOnHover = () => {
     setIsDetailVisible(true);
@@ -16,6 +20,8 @@ const FieldDetailWrapper = ({ children }: FieldDetailWrapperProps) => {
   const handleOnLeave = () => {
     setIsDetailVisible(false);
   };
+
+  const popoverX = TABLE_WIDTH;
 
   return (
     <Group
@@ -28,6 +34,13 @@ const FieldDetailWrapper = ({ children }: FieldDetailWrapperProps) => {
     >
       <Rect x={0} y={0} height={COLUMN_HEIGHT} width={TABLE_WIDTH} />
 
+      {isDetailVisible ? (
+        <Line
+          fill={theme.noteBg}
+          closed
+          points={computeCaretPoints(popoverX, COLUMN_HEIGHT)}
+        />
+      ) : null}
       <Group x={TABLE_WIDTH}>
         <Group x={PADDINGS.xs}>{isDetailVisible ? children : null}</Group>
       </Group>

--- a/packages/json-table-schema-visualizer/src/components/FieldDetails/FieldDetailWrapper.tsx
+++ b/packages/json-table-schema-visualizer/src/components/FieldDetails/FieldDetailWrapper.tsx
@@ -1,0 +1,38 @@
+import { Group, Rect } from "react-konva";
+import { useState, type ReactNode } from "react";
+
+import { COLUMN_HEIGHT, PADDINGS, TABLE_WIDTH } from "@/constants/sizing";
+
+interface FieldDetailWrapperProps {
+  children: ReactNode;
+}
+const FieldDetailWrapper = ({ children }: FieldDetailWrapperProps) => {
+  const [isDetailVisible, setIsDetailVisible] = useState(false);
+
+  const handleOnHover = () => {
+    setIsDetailVisible(true);
+  };
+
+  const handleOnLeave = () => {
+    setIsDetailVisible(false);
+  };
+
+  return (
+    <Group
+      onMouseEnter={handleOnHover}
+      onMouseLeave={handleOnLeave}
+      x={0}
+      y={0}
+      height={COLUMN_HEIGHT}
+      width={TABLE_WIDTH}
+    >
+      <Rect x={0} y={0} height={COLUMN_HEIGHT} width={TABLE_WIDTH} />
+
+      <Group x={TABLE_WIDTH}>
+        <Group x={PADDINGS.xs}>{isDetailVisible ? children : null}</Group>
+      </Group>
+    </Group>
+  );
+};
+
+export default FieldDetailWrapper;

--- a/packages/json-table-schema-visualizer/src/components/FieldDetails/FieldDetails.stories.tsx
+++ b/packages/json-table-schema-visualizer/src/components/FieldDetails/FieldDetails.stories.tsx
@@ -1,0 +1,30 @@
+import FieldDetails from "./FieldDetails";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { exampleData } from "@/fake/fakeJsonTables";
+import MainProviders from "@/providers/MainProviders";
+
+const meta: Meta = {
+  component: FieldDetails,
+  title: "components/FieldDetails",
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FieldDetails>;
+
+export const FieldDetailsStory: Story = {
+  render: (props) => (
+    <MainProviders tables={exampleData.tables} enums={exampleData.enums}>
+      <FieldDetails {...props} />
+    </MainProviders>
+  ),
+  args: {
+    enumName: "status",
+    note: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+  },
+  parameters: {
+    withKonvaWrapper: true,
+  },
+};

--- a/packages/json-table-schema-visualizer/src/components/FieldDetails/FieldDetails.tsx
+++ b/packages/json-table-schema-visualizer/src/components/FieldDetails/FieldDetails.tsx
@@ -1,0 +1,50 @@
+import { Group, Rect } from "react-konva";
+
+import KonvaText from "../dumb/KonvaText";
+
+import EnumDetails from "./EnumDetails";
+import FieldDetailWrapper from "./FieldDetailWrapper";
+
+import { useTheme } from "@/hooks/theme";
+import { computeFieldDetailBoxDimension } from "@/utils/computeFieldDetailBoxDimension";
+import { useGetEnum } from "@/hooks/enums";
+import { PADDINGS } from "@/constants/sizing";
+
+interface FieldDetailsProps {
+  note?: string;
+  enumName?: string;
+}
+
+const FieldDetails = ({ note, enumName = "" }: FieldDetailsProps) => {
+  const theme = useTheme();
+  const enumObject = useGetEnum(enumName);
+
+  const contentDimension = computeFieldDetailBoxDimension(note, enumObject);
+  return (
+    <FieldDetailWrapper>
+      <Group>
+        <Rect
+          fill={theme.noteBg}
+          width={contentDimension.w + PADDINGS.md * 2}
+          height={contentDimension.h}
+          cornerRadius={5}
+        />
+
+        <Group x={PADDINGS.md}>
+          <KonvaText
+            y={PADDINGS.md}
+            width={contentDimension.w}
+            fill={theme.white}
+            text={note}
+          />
+
+          {enumName !== undefined ? (
+            <EnumDetails y={contentDimension.noteH} enumName={enumName} />
+          ) : null}
+        </Group>
+      </Group>
+    </FieldDetailWrapper>
+  );
+};
+
+export default FieldDetails;

--- a/packages/json-table-schema-visualizer/src/components/RelationConnection/RelationConnection.stories.tsx
+++ b/packages/json-table-schema-visualizer/src/components/RelationConnection/RelationConnection.stories.tsx
@@ -5,7 +5,7 @@ import RelationConnection from "./RelationConnection";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { exampleData } from "@/fake/fakeJsonTables";
-import TablesInfoProvider from "@/providers/TablesInfoProvider";
+import MainProviders from "@/providers/MainProviders";
 
 const meta: Meta = {
   component: RelationConnection,
@@ -16,9 +16,9 @@ export default meta;
 
 type Story = StoryObj<typeof RelationConnection>;
 
-export const TableStory: Story = {
+export const RelationConnectionStory: Story = {
   render: (props) => (
-    <TablesInfoProvider tables={exampleData.tables}>
+    <MainProviders enums={exampleData.enums} tables={exampleData.tables}>
       <RelationConnection {...props} />
 
       <Table {...exampleData.tables[0]} />
@@ -26,7 +26,7 @@ export const TableStory: Story = {
       <Table {...exampleData.tables[1]} />
 
       <Table {...exampleData.tables[2]} />
-    </TablesInfoProvider>
+    </MainProviders>
   ),
   args: {
     source: exampleData.refs[0].endpoints[0],

--- a/packages/json-table-schema-visualizer/src/components/Table.stories.tsx
+++ b/packages/json-table-schema-visualizer/src/components/Table.stories.tsx
@@ -2,8 +2,8 @@ import Table from "./Table";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import TablesInfoProvider from "@/providers/TablesInfoProvider";
 import { exampleData } from "@/fake/fakeJsonTables";
+import MainProviders from "@/providers/MainProviders";
 
 const meta: Meta = {
   component: Table,
@@ -16,9 +16,9 @@ type Story = StoryObj<typeof Table>;
 
 export const TableStory: Story = {
   render: (props) => (
-    <TablesInfoProvider tables={exampleData.tables}>
+    <MainProviders enums={exampleData.enums} tables={exampleData.tables}>
       <Table {...props} />
-    </TablesInfoProvider>
+    </MainProviders>
   ),
   args: {
     ...exampleData.tables[0],

--- a/packages/json-table-schema-visualizer/src/components/Table.tsx
+++ b/packages/json-table-schema-visualizer/src/components/Table.tsx
@@ -81,6 +81,7 @@ const Table = ({ fields, name }: TableProps) => {
             key={field.name}
             colName={field.name}
             tableName={name}
+            isEnum={field.type.is_enum}
             type={field.type.type_name}
             isPrimaryKey={field.pk}
             offsetY={index * COLUMN_HEIGHT}

--- a/packages/json-table-schema-visualizer/src/components/dumb/KonvaText.tsx
+++ b/packages/json-table-schema-visualizer/src/components/dumb/KonvaText.tsx
@@ -3,9 +3,10 @@ import { Text } from "react-konva";
 import type Konva from "konva";
 
 import { FONT_FAMILY } from "@/constants/font";
+import { FONT_SIZES } from "@/constants/sizing";
 
 const KonvaText = (props: Konva.TextConfig) => {
-  return <Text fontFamily={FONT_FAMILY} {...props} />;
+  return <Text fontFamily={FONT_FAMILY} fontSize={FONT_SIZES.md} {...props} />;
 };
 
 export default KonvaText;

--- a/packages/json-table-schema-visualizer/src/constants/sizing.ts
+++ b/packages/json-table-schema-visualizer/src/constants/sizing.ts
@@ -15,9 +15,18 @@ export const CONNECTION_HANDLE_OFFSET = 20;
 export const PADDINGS = {
   xs: 5,
   sm: 8,
+  md: 10,
+  lg: 20,
 };
 
 export const FONT_SIZES = {
   md: 13,
   lg: 15,
 };
+
+export const FIELD_DETAILS_CARET = {
+  w: 5,
+  h: 5,
+};
+
+export const FIELD_DETAILS_TOOLTIPS_W = 200;

--- a/packages/json-table-schema-visualizer/src/constants/theme.ts
+++ b/packages/json-table-schema-visualizer/src/constants/theme.ts
@@ -18,4 +18,9 @@ export const defaultThemeConfig: ThemeConfigValue = {
     bg: "#F8FAFC",
     fg: "black",
   },
+  red: "red",
+  green: "green",
+  enumItem: "#ccc",
+  white: "white",
+  noteBg: "#000000d6",
 };

--- a/packages/json-table-schema-visualizer/src/hooks/enums.ts
+++ b/packages/json-table-schema-visualizer/src/hooks/enums.ts
@@ -1,0 +1,21 @@
+import { useContext } from "react";
+import { type JSONTableEnum } from "shared/types/tableSchema";
+
+import { EnumsContext } from "@/providers/EnumsProvider";
+import { type EnumsContextValue } from "@/types/enums";
+
+export const useEnums = (): EnumsContextValue => {
+  const value = useContext(EnumsContext);
+
+  if (value == null) {
+    throw new Error("useEnums must be used within an EnumsProvider");
+  }
+
+  return value;
+};
+
+export const useGetEnum = (enumName: string): JSONTableEnum | undefined => {
+  const value = useEnums();
+
+  return value.enums.find((en) => en.name === enumName);
+};

--- a/packages/json-table-schema-visualizer/src/providers/EnumsProvider.tsx
+++ b/packages/json-table-schema-visualizer/src/providers/EnumsProvider.tsx
@@ -1,0 +1,18 @@
+import { createContext, type ReactNode } from "react";
+import { type JSONTableEnum } from "shared/types/tableSchema";
+
+import { type EnumsContextValue } from "@/types/enums";
+
+export const EnumsContext = createContext<EnumsContextValue | null>(null);
+
+interface EnumsProviderProps {
+  children: ReactNode;
+  enums: JSONTableEnum[];
+}
+const EnumsProvider = ({ children, enums }: EnumsProviderProps) => {
+  return (
+    <EnumsContext.Provider value={{ enums }}>{children}</EnumsContext.Provider>
+  );
+};
+
+export default EnumsProvider;

--- a/packages/json-table-schema-visualizer/src/providers/MainProviders.tsx
+++ b/packages/json-table-schema-visualizer/src/providers/MainProviders.tsx
@@ -1,0 +1,23 @@
+import {
+  type JSONTableEnum,
+  type JSONTableTable,
+} from "shared/types/tableSchema";
+import { type ReactNode } from "react";
+
+import TablesInfoProvider from "./TablesInfoProvider";
+import EnumsProvider from "./EnumsProvider";
+
+interface MainProvidersProps {
+  tables: JSONTableTable[];
+  enums: JSONTableEnum[];
+  children: ReactNode;
+}
+const MainProviders = ({ enums, tables, children }: MainProvidersProps) => {
+  return (
+    <TablesInfoProvider tables={tables}>
+      <EnumsProvider enums={enums}>{children}</EnumsProvider>
+    </TablesInfoProvider>
+  );
+};
+
+export default MainProviders;

--- a/packages/json-table-schema-visualizer/src/types/dimension.ts
+++ b/packages/json-table-schema-visualizer/src/types/dimension.ts
@@ -1,0 +1,4 @@
+export interface Dimension {
+  width: number;
+  height: number;
+}

--- a/packages/json-table-schema-visualizer/src/types/enums.ts
+++ b/packages/json-table-schema-visualizer/src/types/enums.ts
@@ -1,0 +1,5 @@
+import type { JSONTableEnum } from "shared/types/tableSchema";
+
+export interface EnumsContextValue {
+  enums: JSONTableEnum[];
+}

--- a/packages/json-table-schema-visualizer/src/types/theme.tsx
+++ b/packages/json-table-schema-visualizer/src/types/theme.tsx
@@ -16,4 +16,9 @@ export interface ThemeConfigValue {
     bg: string;
     shadow: string;
   };
+  red: string;
+  green: string;
+  enumItem: string;
+  white: string;
+  noteBg: string;
 }

--- a/packages/json-table-schema-visualizer/src/utils/computeCaretPoints.ts
+++ b/packages/json-table-schema-visualizer/src/utils/computeCaretPoints.ts
@@ -1,0 +1,10 @@
+import { FIELD_DETAILS_CARET } from "@/constants/sizing";
+
+export const computeCaretPoints = (
+  startingX: number,
+  colHeight: number,
+): number[] => {
+  const colHalf = colHeight / 2;
+  const caretX2 = startingX + FIELD_DETAILS_CARET.w;
+  return [startingX, colHalf, caretX2, colHalf - 5, caretX2, colHalf + 5];
+};

--- a/packages/json-table-schema-visualizer/src/utils/computeEnumDetailBoxMaxW.ts
+++ b/packages/json-table-schema-visualizer/src/utils/computeEnumDetailBoxMaxW.ts
@@ -1,0 +1,9 @@
+import { type JSONTableEnum } from "shared/types/tableSchema";
+
+import { computeTextsMaxWidth } from "./computeTextsMaxWidth";
+
+export const computeEnumDetailBoxMaxW = (enumObject: JSONTableEnum): number => {
+  const titleText = `Enum ${enumObject.name}`;
+  const itemsTexts = enumObject.values.map((item) => ` - ${item.name}`);
+  return computeTextsMaxWidth([titleText, ...itemsTexts]);
+};

--- a/packages/json-table-schema-visualizer/src/utils/computeFieldDetailBoxDimension.ts
+++ b/packages/json-table-schema-visualizer/src/utils/computeFieldDetailBoxDimension.ts
@@ -1,0 +1,37 @@
+import { type JSONTableEnum } from "shared/types/tableSchema";
+
+import { computeEnumDetailBoxMaxW } from "./computeEnumDetailBoxMaxW";
+import { getLetterApproximateDimension } from "./computeTextSize";
+import { estimateSentenceLineCount } from "./estimateSentenceLineCount";
+
+import { FIELD_DETAILS_TOOLTIPS_W, PADDINGS } from "@/constants/sizing";
+
+export const computeFieldDetailBoxDimension = (
+  note?: string,
+  enumObject?: JSONTableEnum,
+): { w: number; h: number; noteH: number } => {
+  const enumDetailMaxW =
+    enumObject === undefined ? 0 : computeEnumDetailBoxMaxW(enumObject);
+  const finalW = Math.max(enumDetailMaxW, FIELD_DETAILS_TOOLTIPS_W);
+
+  const letterApproximateDim = getLetterApproximateDimension();
+  const noteH =
+    note !== undefined
+      ? estimateSentenceLineCount(note, finalW) * letterApproximateDim.height
+      : 0;
+
+  const enumsDetailsH =
+    enumObject === undefined
+      ? 0
+      : letterApproximateDim.height *
+        /* the 1 added is for the title line */ (1 + enumObject.values.length);
+
+  const noteHWithPadding = noteH + PADDINGS.lg;
+  const totalH =
+    enumsDetailsH +
+    noteHWithPadding +
+    // add bottom padding
+    PADDINGS.md;
+
+  return { w: finalW, h: totalH, noteH: noteHWithPadding };
+};

--- a/packages/json-table-schema-visualizer/src/utils/computeFieldDetailBoxDimension.ts
+++ b/packages/json-table-schema-visualizer/src/utils/computeFieldDetailBoxDimension.ts
@@ -15,18 +15,18 @@ export const computeFieldDetailBoxDimension = (
   const finalW = Math.max(enumDetailMaxW, FIELD_DETAILS_TOOLTIPS_W);
 
   const letterApproximateDim = getLetterApproximateDimension();
-  const noteH =
-    note !== undefined
-      ? estimateSentenceLineCount(note, finalW) * letterApproximateDim.height
-      : 0;
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+  const noteH = note
+    ? estimateSentenceLineCount(note, finalW) * letterApproximateDim.height
+    : 0;
 
   const enumsDetailsH =
     enumObject === undefined
       ? 0
       : letterApproximateDim.height *
-        /* the 1 added is for the title line */ (1 + enumObject.values.length);
+        (1 + enumObject.values.length); /* the 1 added is for the title line */
 
-  const noteHWithPadding = noteH + PADDINGS.lg;
+  const noteHWithPadding = noteH + (noteH !== 0 ? PADDINGS.lg : PADDINGS.md);
   const totalH =
     enumsDetailsH +
     noteHWithPadding +

--- a/packages/json-table-schema-visualizer/src/utils/computeTextSize.ts
+++ b/packages/json-table-schema-visualizer/src/utils/computeTextSize.ts
@@ -1,0 +1,28 @@
+import { Text, type TextConfig } from "konva/lib/shapes/Text";
+
+import { FONT_FAMILY } from "@/constants/font";
+import { FONT_SIZES } from "@/constants/sizing";
+import { type Dimension } from "@/types/dimension";
+
+const textNode = new Text({
+  fontFamily: FONT_FAMILY,
+  fontSize: FONT_SIZES.md,
+});
+
+export const computeTextSize = (
+  text: string,
+  config?: TextConfig,
+): Dimension => {
+  if (config != null) {
+    const clone = textNode.clone(config);
+    return clone.measureSize(text);
+  }
+
+  return textNode.measureSize(text);
+};
+
+export const getLetterApproximateDimension = (
+  config?: TextConfig,
+): Dimension => {
+  return computeTextSize("a", config);
+};

--- a/packages/json-table-schema-visualizer/src/utils/computeTextsMaxWidth.ts
+++ b/packages/json-table-schema-visualizer/src/utils/computeTextsMaxWidth.ts
@@ -1,0 +1,5 @@
+import { computeTextSize } from "./computeTextSize";
+
+export const computeTextsMaxWidth = (text: string[]): number => {
+  return Math.max(...text.map((t) => computeTextSize(t).width));
+};

--- a/packages/json-table-schema-visualizer/src/utils/estimateSentenceLineCount.ts
+++ b/packages/json-table-schema-visualizer/src/utils/estimateSentenceLineCount.ts
@@ -1,0 +1,21 @@
+import { computeTextSize } from "./computeTextSize";
+
+export const estimateSentenceLineCount = (
+  sentence: string,
+  containerW: number,
+): number => {
+  let numberOfLine = 1;
+  let accumulatedWidth = 0;
+
+  sentence.split(" ").forEach((word) => {
+    const wordW = computeTextSize(`${word}-`).width;
+    accumulatedWidth += wordW;
+    if (accumulatedWidth > containerW) {
+      const approximateLineForTheWord = Math.ceil(wordW / containerW);
+      numberOfLine += approximateLineForTheWord;
+      accumulatedWidth = 0;
+    }
+  });
+
+  return numberOfLine;
+};

--- a/packages/json-table-schema-visualizer/src/utils/tests/computeCaretPoints.test.ts
+++ b/packages/json-table-schema-visualizer/src/utils/tests/computeCaretPoints.test.ts
@@ -1,0 +1,7 @@
+import { computeCaretPoints } from "../computeCaretPoints";
+
+describe("compute field detail popover caret points", () => {
+  test("compute field detail popover caret points", () => {
+    expect(computeCaretPoints(0, 10)).toEqual([0, 5, 5, 0, 5, 10]);
+  });
+});

--- a/packages/json-table-schema-visualizer/src/utils/tests/computeTextsMaxWidth.test.ts
+++ b/packages/json-table-schema-visualizer/src/utils/tests/computeTextsMaxWidth.test.ts
@@ -1,0 +1,10 @@
+import { computeTextSize } from "../computeTextSize";
+import { computeTextsMaxWidth } from "../computeTextsMaxWidth";
+
+describe("get the more longer text width", () => {
+  test("get the more longer text width", () => {
+    expect(computeTextsMaxWidth(["simple", "more longer"])).toBe(
+      computeTextSize("more longer"),
+    );
+  });
+});


### PR DESCRIPTION
Add the popover/tooltip for field details

<img width="430" alt="image" src="https://github.com/BOCOVO/db-schema-visualizer/assets/51182814/9c6bb35e-9116-46e3-9cfc-d8aabea3b084">
