### PR TITLE
fix(visualizer): resolve connection points are not updated

### DIFF
--- a/packages/json-table-schema-visualizer/src/components/Table.tsx
+++ b/packages/json-table-schema-visualizer/src/components/Table.tsx
@@ -32,6 +32,7 @@ const Table = ({ fields, name }: TableProps) => {
     if (tableRef.current != null && tablePosition.length === 2) {
       tableRef.current.x(tablePosition[0]);
       tableRef.current.y(tablePosition[1]);
+      propagateCoordinates(tableRef.current);
     }
   }, [tablePosition]);
 


### PR DESCRIPTION
Fix the relation connection point are not update after
pressing the preview button while the preview panel is already
opened