### PR TITLE
Feat(visualizer): Make the width of table diagrams adaptive to their content

### DIFF
--- a/packages/dbml-vs-code-extension/CHANGELOG.md
+++ b/packages/dbml-vs-code-extension/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "dbml-erd-visualizer" extension will be documented in
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+
+### Added
+
+- Make the table width fit the table content
+
 ## [0.0.2]
 
 ### Added

--- a/packages/json-table-schema-visualizer/src/components/Column/Column.tsx
+++ b/packages/json-table-schema-visualizer/src/components/Column/Column.tsx
@@ -8,9 +8,10 @@ import {
   COLUMN_HEIGHT,
   FONT_SIZES,
   PADDINGS,
-  TABLE_WIDTH,
+  TABLE_FIELD_TYPE_PADDING,
 } from "@/constants/sizing";
 import { useThemeColors } from "@/hooks/theme";
+import { useTableWidth } from "@/hooks/table";
 
 interface ColumnProps {
   colName: string;
@@ -35,6 +36,7 @@ const Column = ({
 }: ColumnProps) => {
   const themeColors = useThemeColors();
   const tableColors = useTableColor(tableName);
+  const tablePreferredWidth = useTableWidth();
 
   const colTextColor = themeColors.text[900];
   const typeTextColor = themeColors.text[700];
@@ -55,7 +57,7 @@ const Column = ({
             text={colName}
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing
             fill={(highlighted && tableColors?.regular) || colTextColor}
-            width={TABLE_WIDTH}
+            width={tablePreferredWidth}
             fontStyle={fontStyle}
             padding={PADDINGS.sm}
             height={COLUMN_HEIGHT}
@@ -63,12 +65,12 @@ const Column = ({
           />
 
           <KonvaText
-            text={isEnum ? `${type} 🅴` : type}
+            text={type}
             align="right"
-            width={TABLE_WIDTH}
+            width={tablePreferredWidth}
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing
             fill={(highlighted && tableColors?.regular) || typeTextColor}
-            padding={PADDINGS.sm}
+            padding={TABLE_FIELD_TYPE_PADDING}
             fontStyle={fontStyle}
             fontSize={FONT_SIZES.md}
             height={COLUMN_HEIGHT}

--- a/packages/json-table-schema-visualizer/src/components/Column/ColumnWrapper.tsx
+++ b/packages/json-table-schema-visualizer/src/components/Column/ColumnWrapper.tsx
@@ -1,8 +1,8 @@
 import { type ReactNode, useState } from "react";
 import { Group, Rect } from "react-konva";
 
-import { COLUMN_HEIGHT, TABLE_WIDTH } from "@/constants/sizing";
-import { useTablesInfo } from "@/hooks/table";
+import { COLUMN_HEIGHT } from "@/constants/sizing";
+import { useTablesInfo, useTableWidth } from "@/hooks/table";
 import { shouldHighLightCol } from "@/utils/shouldHighLightCol";
 
 interface ColumnWrapperProps {
@@ -22,6 +22,7 @@ const ColumnWrapper = ({
 }: ColumnWrapperProps) => {
   const { hoveredTableName } = useTablesInfo();
   const [hovered, setHovered] = useState(false);
+  const tablePreferredWidth = useTableWidth();
 
   const handleOnHover = () => {
     setHovered(true);
@@ -42,7 +43,7 @@ const ColumnWrapper = ({
     <Group onMouseOver={handleOnHover} onMouseLeave={handleOnLeave} y={offsetY}>
       <Rect
         fill={highlighted ? highlightColor : "transparent"}
-        width={TABLE_WIDTH}
+        width={tablePreferredWidth}
         height={COLUMN_HEIGHT}
       />
       {children(highlighted)}

--- a/packages/json-table-schema-visualizer/src/components/DiagramViewer/Tables.tsx
+++ b/packages/json-table-schema-visualizer/src/components/DiagramViewer/Tables.tsx
@@ -1,13 +1,13 @@
 import { type JSONTableTable } from "shared/types/tableSchema";
 
-import Table from "../Table";
+import TableWrapper from "../TableWrapper";
 
 interface TablesProps {
   tables: JSONTableTable[];
 }
 
 const Tables = ({ tables }: TablesProps) => {
-  return tables.map((table) => <Table key={table.name} {...table} />);
+  return tables.map((table) => <TableWrapper key={table.name} table={table} />);
 };
 
 export default Tables;

--- a/packages/json-table-schema-visualizer/src/components/FieldDetails/FieldDetailWrapper.tsx
+++ b/packages/json-table-schema-visualizer/src/components/FieldDetails/FieldDetailWrapper.tsx
@@ -1,9 +1,10 @@
 import { Group, Line, Rect } from "react-konva";
 import { useState, type ReactNode } from "react";
 
-import { COLUMN_HEIGHT, PADDINGS, TABLE_WIDTH } from "@/constants/sizing";
+import { COLUMN_HEIGHT, PADDINGS } from "@/constants/sizing";
 import { useThemeColors } from "@/hooks/theme";
 import { computeCaretPoints } from "@/utils/computeCaretPoints";
+import { useTableWidth } from "@/hooks/table";
 
 interface FieldDetailWrapperProps {
   children: ReactNode;
@@ -12,7 +13,7 @@ interface FieldDetailWrapperProps {
 const FieldDetailWrapper = ({ children }: FieldDetailWrapperProps) => {
   const [isDetailVisible, setIsDetailVisible] = useState(false);
   const themeColors = useThemeColors();
-
+  const tablePreferredWidth = useTableWidth();
   const handleOnHover = () => {
     setIsDetailVisible(true);
   };
@@ -21,7 +22,7 @@ const FieldDetailWrapper = ({ children }: FieldDetailWrapperProps) => {
     setIsDetailVisible(false);
   };
 
-  const popoverX = TABLE_WIDTH;
+  const popoverX = tablePreferredWidth;
 
   return (
     <Group
@@ -30,9 +31,9 @@ const FieldDetailWrapper = ({ children }: FieldDetailWrapperProps) => {
       x={0}
       y={0}
       height={COLUMN_HEIGHT}
-      width={TABLE_WIDTH}
+      width={tablePreferredWidth}
     >
-      <Rect x={0} y={0} height={COLUMN_HEIGHT} width={TABLE_WIDTH} />
+      <Rect x={0} y={0} height={COLUMN_HEIGHT} width={tablePreferredWidth} />
 
       {isDetailVisible ? (
         <Line
@@ -41,7 +42,7 @@ const FieldDetailWrapper = ({ children }: FieldDetailWrapperProps) => {
           points={computeCaretPoints(popoverX, COLUMN_HEIGHT)}
         />
       ) : null}
-      <Group x={TABLE_WIDTH}>
+      <Group x={tablePreferredWidth}>
         <Group x={PADDINGS.xs}>{isDetailVisible ? children : null}</Group>
       </Group>
     </Group>

--- a/packages/json-table-schema-visualizer/src/components/Table.tsx
+++ b/packages/json-table-schema-visualizer/src/components/Table.tsx
@@ -13,12 +13,11 @@ import {
   PADDINGS,
   TABLE_COLOR_HEIGHT,
   TABLE_HEADER_HEIGHT,
-  TABLE_WIDTH,
 } from "@/constants/sizing";
 import { useThemeColors } from "@/hooks/theme";
 import eventEmitter from "@/events-emitter";
 import { computeTableDragEventName } from "@/utils/eventName";
-import { useTablePosition, useTablesInfo } from "@/hooks/table";
+import { useTablePosition, useTablesInfo, useTableWidth } from "@/hooks/table";
 import { tableCoordsStore } from "@/stores/tableCoords";
 
 interface TableProps extends JSONTableTable {}
@@ -28,6 +27,7 @@ const Table = ({ fields, name }: TableProps) => {
   const tableRef = useRef<null | Konva.Group>(null);
   const { setHoveredTableName } = useTablesInfo();
   const tablePosition = useTablePosition(name);
+  const tablePreferredWidth = useTableWidth();
 
   useEffect(() => {
     if (tableRef.current != null && tablePosition.length === 2) {
@@ -85,7 +85,7 @@ const Table = ({ fields, name }: TableProps) => {
       ref={tableRef}
       draggable
       onDragMove={handleOnDrag}
-      width={TABLE_WIDTH}
+      width={tablePreferredWidth}
       height={tableHeight}
       onMouseEnter={handleOnHover}
       onMouseLeave={handleOnBlur}
@@ -96,7 +96,7 @@ const Table = ({ fields, name }: TableProps) => {
         shadowOpacity={0.2}
         shadowColor={themeColors.table.shadow}
         height={tableHeight}
-        width={TABLE_WIDTH}
+        width={tablePreferredWidth}
         fill={themeColors.table.bg}
         cornerRadius={PADDINGS.sm}
       />

--- a/packages/json-table-schema-visualizer/src/components/TableHeader.tsx
+++ b/packages/json-table-schema-visualizer/src/components/TableHeader.tsx
@@ -7,10 +7,10 @@ import {
   FONT_SIZES,
   PADDINGS,
   TABLE_COLOR_HEIGHT,
-  TABLE_WIDTH,
 } from "@/constants/sizing";
 import { useThemeColors } from "@/hooks/theme";
 import { useTableColor } from "@/hooks/tableColor";
+import { useTableWidth } from "@/hooks/table";
 
 interface TableHeaderProps {
   title: string;
@@ -19,7 +19,7 @@ interface TableHeaderProps {
 const TableHeader = ({ title }: TableHeaderProps) => {
   const themeColors = useThemeColors();
   const tableColors = useTableColor(title);
-
+  const tablePreferredWidth = useTableWidth();
   const tableMarkerColor = tableColors?.regular ?? "red";
 
   return (
@@ -28,13 +28,13 @@ const TableHeader = ({ title }: TableHeaderProps) => {
         cornerRadius={[PADDINGS.sm, PADDINGS.sm]}
         fill={tableMarkerColor}
         height={TABLE_COLOR_HEIGHT}
-        width={TABLE_WIDTH}
+        width={tablePreferredWidth}
       />
 
       <Rect
         y={TABLE_COLOR_HEIGHT}
         fill={themeColors.tableHeader.bg}
-        width={TABLE_WIDTH}
+        width={tablePreferredWidth}
         height={COLUMN_HEIGHT}
       />
 
@@ -42,7 +42,7 @@ const TableHeader = ({ title }: TableHeaderProps) => {
         text={title}
         y={TABLE_COLOR_HEIGHT}
         fill={themeColors.tableHeader.fg}
-        width={TABLE_WIDTH}
+        width={tablePreferredWidth}
         height={COLUMN_HEIGHT}
         align="center"
         strokeWidth={PADDINGS.xs}

--- a/packages/json-table-schema-visualizer/src/components/TableWrapper.tsx
+++ b/packages/json-table-schema-visualizer/src/components/TableWrapper.tsx
@@ -1,0 +1,22 @@
+import { type JSONTableTable } from "shared/types/tableSchema";
+
+import Table from "./Table";
+
+import { useGetTableMinWidth } from "@/hooks/table";
+import TableDimensionProvider from "@/providers/TableDimension";
+
+interface TableWrapperProps {
+  table: JSONTableTable;
+}
+
+const TableWrapper = ({ table }: TableWrapperProps) => {
+  const width = useGetTableMinWidth(table);
+
+  return (
+    <TableDimensionProvider width={width}>
+      <Table {...table} />
+    </TableDimensionProvider>
+  );
+};
+
+export default TableWrapper;

--- a/packages/json-table-schema-visualizer/src/constants/sizing.ts
+++ b/packages/json-table-schema-visualizer/src/constants/sizing.ts
@@ -1,4 +1,4 @@
-export const TABLE_WIDTH = 180;
+export const TABLE_DEFAULT_MIN_WIDTH = 150;
 export const TABLE_COLOR_HEIGHT = 6;
 export const TABLE_LINE_HEIGHT = 25;
 export const COLUMN_HEIGHT = 30;
@@ -18,6 +18,7 @@ export const PADDINGS = {
   md: 10,
   lg: 20,
 };
+export const TABLE_FIELD_TYPE_PADDING = PADDINGS.sm;
 
 export const FONT_SIZES = {
   md: 15,

--- a/packages/json-table-schema-visualizer/src/hooks/relationConnection.ts
+++ b/packages/json-table-schema-visualizer/src/hooks/relationConnection.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { useTablesInfo } from "./table";
+import { useTableWidthStoredValue } from "./tableWidthStore";
 
 import type { RelationItem } from "@/types/relation";
 import type { Position, XYPosition } from "@/types/positions";
@@ -9,7 +10,6 @@ import { computeColY } from "@/utils/computeColY";
 import { computeTableDragEventName } from "@/utils/eventName";
 import eventEmitter from "@/events-emitter";
 import { computeConnectionHandlePos } from "@/utils/computeConnectionHandlePositions";
-import { TABLE_WIDTH } from "@/constants/sizing";
 import { tableCoordsStore } from "@/stores/tableCoords";
 
 interface UseRelationTablesCoordsReturn {
@@ -58,6 +58,9 @@ export const useRelationsCoords = (
   );
   const [sourceColY, targetColY] = useRelationsColsY(source, target);
 
+  const sourceTableWidth = useTableWidthStoredValue(source.tableName);
+  const targetTableWidth = useTableWidthStoredValue(target.tableName);
+
   const sourceTableDragEventName = computeTableDragEventName(source?.tableName);
   const targetTableDragEventName = computeTableDragEventName(target?.tableName);
 
@@ -89,9 +92,9 @@ export const useRelationsCoords = (
 
   const [sourcePosition, targetPosition, finalSourceX, finalTargetX] =
     computeConnectionHandlePos({
-      sourceW: TABLE_WIDTH,
+      sourceW: sourceTableWidth,
       sourceX: sourceTableCoords.x,
-      targetW: TABLE_WIDTH,
+      targetW: targetTableWidth,
       targetX: targetTableCoords.x,
     });
 

--- a/packages/json-table-schema-visualizer/src/hooks/table.ts
+++ b/packages/json-table-schema-visualizer/src/hooks/table.ts
@@ -1,9 +1,15 @@
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
+import { type JSONTableTable } from "shared/types/tableSchema";
 
 import type { TablesInfoProviderValue } from "@/types/tablesInfoProviderValue";
 
 import { TablesInfoContext } from "@/providers/TablesInfoProvider";
 import { TablesPositionsContext } from "@/providers/TablesPositionsProvider";
+import { TableDimensionContext } from "@/providers/TableDimension";
+import { TABLE_DEFAULT_MIN_WIDTH } from "@/constants/sizing";
+import { getTableLinesText } from "@/utils/tableWComputation/getTableLinesText";
+import { computeTablePreferredWidth } from "@/utils/tableWComputation/computeTablePreferredWidth";
+import { tableWidthStore } from "@/stores/tableWidth";
 
 export const useTablesInfo = (): TablesInfoProviderValue => {
   const tablesInfo = useContext(TablesInfoContext);
@@ -25,4 +31,21 @@ export const useTablePosition = (tableName: string): [number, number] | [] => {
   }
 
   return tablesPositionsMap.tablesPositions.get(tableName) ?? [];
+};
+
+export const useGetTableMinWidth = (table: JSONTableTable): number => {
+  const tableLinesTexts = getTableLinesText(table.fields, table.name);
+  const minWidth = useMemo(() => {
+    const minW = computeTablePreferredWidth(tableLinesTexts);
+    tableWidthStore.setWidth(table.name, minW);
+    return minW;
+  }, [tableLinesTexts]);
+
+  return minWidth;
+};
+
+export const useTableWidth = (): number => {
+  const contextValue = useContext(TableDimensionContext);
+
+  return contextValue?.width ?? TABLE_DEFAULT_MIN_WIDTH;
 };

--- a/packages/json-table-schema-visualizer/src/hooks/tableWidthStore.ts
+++ b/packages/json-table-schema-visualizer/src/hooks/tableWidthStore.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from "react";
+
+import { tableWidthStore } from "@/stores/tableWidth";
+
+export const useTableWidthStoredValue = (tableName: string): number => {
+  const registerSubscriber = (callback: (w: number) => void): (() => void) => {
+    tableWidthStore.subscribe(tableName, callback);
+
+    // return function that unsubscribe
+    return () => {
+      tableWidthStore.unSubscribe(tableName, callback);
+    };
+  };
+
+  const getCurrentValue = (): number =>
+    tableWidthStore.getWidth(tableName) ?? 0;
+
+  const width = useSyncExternalStore(registerSubscriber, getCurrentValue);
+
+  return width;
+};

--- a/packages/json-table-schema-visualizer/src/providers/TableDimension.tsx
+++ b/packages/json-table-schema-visualizer/src/providers/TableDimension.tsx
@@ -1,0 +1,30 @@
+import { createContext, useMemo, type ReactNode } from "react";
+
+import type { TableDimensionProviderValue } from "@/types/table";
+
+export const TableDimensionContext = createContext<
+  TableDimensionProviderValue | undefined
+>(undefined);
+
+interface TablesInfoProviderProps {
+  width: number;
+  children: ReactNode;
+}
+
+// only store the width of the table at this time
+const TableDimensionProvider = ({
+  children,
+  width,
+}: TablesInfoProviderProps) => {
+  const contextValue = useMemo(() => {
+    return { width };
+  }, [width]);
+
+  return (
+    <TableDimensionContext.Provider value={contextValue}>
+      {children}
+    </TableDimensionContext.Provider>
+  );
+};
+
+export default TableDimensionProvider;

--- a/packages/json-table-schema-visualizer/src/stores/StoreSignal.ts
+++ b/packages/json-table-schema-visualizer/src/stores/StoreSignal.ts
@@ -1,0 +1,29 @@
+import eventEmitter from "@/events-emitter";
+
+export class StoreSignal<T> {
+  private readonly storeEventPrefix: string;
+
+  constructor(storeName: string) {
+    this.storeEventPrefix = `store:${storeName}`;
+  }
+
+  getEventName(eventKey: string): string {
+    return `${this.storeEventPrefix}:${eventKey}`;
+  }
+
+  subscribe(eventKey: string, callback: (value: T) => void): void {
+    const eventName = this.getEventName(eventKey);
+    eventEmitter.on(eventName, callback);
+  }
+
+  unSubscribe(eventKey: string, callback: (value: T) => void): void {
+    const eventName = this.getEventName(eventKey);
+
+    eventEmitter.off(eventName, callback);
+  }
+
+  protected emit(eventKey: string, value: T): void {
+    const eventName = this.getEventName(eventKey);
+    eventEmitter.emit(eventName, value);
+  }
+}

--- a/packages/json-table-schema-visualizer/src/stores/tableCoords.ts
+++ b/packages/json-table-schema-visualizer/src/stores/tableCoords.ts
@@ -2,7 +2,6 @@ import type { XYPosition } from "@/types/positions";
 
 // to track tables position. react context do the job but it will
 // require to have a lot of components memoization for better performance
-export const tableCoords = new Map<string, XYPosition>();
 
 class TableCoordsStore {
   private readonly tableCoords = new Map<string, XYPosition>();

--- a/packages/json-table-schema-visualizer/src/stores/tableWidth.ts
+++ b/packages/json-table-schema-visualizer/src/stores/tableWidth.ts
@@ -1,5 +1,11 @@
-class TableWidthStore {
+import { StoreSignal } from "./StoreSignal";
+
+class TableWidthStore extends StoreSignal<number> {
   private readonly tableWidths = new Map<string, number>();
+
+  constructor() {
+    super("tableWidth");
+  }
 
   public getWidth(tableName: string): number | undefined {
     return this.tableWidths.get(tableName);
@@ -7,6 +13,7 @@ class TableWidthStore {
 
   public setWidth(table: string, width: number): void {
     this.tableWidths.set(table, width);
+    this.emit(table, width);
   }
 
   public remove(table: string): void {

--- a/packages/json-table-schema-visualizer/src/stores/tableWidth.ts
+++ b/packages/json-table-schema-visualizer/src/stores/tableWidth.ts
@@ -1,0 +1,17 @@
+class TableWidthStore {
+  private readonly tableWidths = new Map<string, number>();
+
+  public getWidth(tableName: string): number | undefined {
+    return this.tableWidths.get(tableName);
+  }
+
+  public setWidth(table: string, width: number): void {
+    this.tableWidths.set(table, width);
+  }
+
+  public remove(table: string): void {
+    this.tableWidths.delete(table);
+  }
+}
+
+export const tableWidthStore = new TableWidthStore();

--- a/packages/json-table-schema-visualizer/src/types/table.ts
+++ b/packages/json-table-schema-visualizer/src/types/table.ts
@@ -1,0 +1,3 @@
+export interface TableDimensionProviderValue {
+  width: number;
+}

--- a/packages/json-table-schema-visualizer/src/utils/computeTableDimension.ts
+++ b/packages/json-table-schema-visualizer/src/utils/computeTableDimension.ts
@@ -1,15 +1,14 @@
 import { type JSONTableTable } from "shared/types/tableSchema";
 
-import {
-  COLUMN_HEIGHT,
-  TABLE_HEADER_HEIGHT,
-  TABLE_WIDTH,
-} from "@/constants/sizing";
+import { getTableLinesText } from "./tableWComputation/getTableLinesText";
+import { computeTablePreferredWidth } from "./tableWComputation/computeTablePreferredWidth";
+
+import { COLUMN_HEIGHT, TABLE_HEADER_HEIGHT } from "@/constants/sizing";
 import { type Dimension } from "@/types/dimension";
 
 export const computeTableDimension = (table: JSONTableTable): Dimension => {
-  // use the default width for tables
-  const width = TABLE_WIDTH;
+  const tableTexts = getTableLinesText(table.fields, table.name);
+  const width = computeTablePreferredWidth(tableTexts);
   const height = TABLE_HEADER_HEIGHT + COLUMN_HEIGHT * table.fields.length;
 
   return { width, height };

--- a/packages/json-table-schema-visualizer/src/utils/tablePositioning/computeTablesPositions.ts
+++ b/packages/json-table-schema-visualizer/src/utils/tablePositioning/computeTablesPositions.ts
@@ -11,27 +11,40 @@ const computeTablesPositions = (
 ): Map<string, [number, number]> => {
   const colNumber = getColsNumber(tables.length);
 
-  const nextColsY = new Map<number, number>();
-
-  let nextTableX = 0;
+  let nextColsY = 0;
 
   const tablesPositions = new Map<string, [number, number]>();
+  let nextTableX = 0;
 
-  tables.forEach((table, index) => {
-    const colIndex = index % colNumber;
-    const colY = nextColsY.get(colIndex) ?? 0;
+  for (let colIndex = 0; colIndex < colNumber; colIndex++) {
+    let currentColMaxW = 0;
 
-    tablesPositions.set(table.name, [nextTableX, colY]);
+    const currentColX = nextTableX;
 
-    const tableDimension = computeTableDimension(table);
-    const nextColY = colY + tableDimension.height + TABLES_GAP_Y;
-    nextColsY.set(colIndex, nextColY);
+    for (
+      let tableIndex = colIndex;
+      tableIndex < tables.length;
+      tableIndex += colNumber
+    ) {
+      const table = tables[tableIndex];
+      const colY = nextColsY ?? 0;
 
-    nextTableX =
-      colIndex === colNumber - 1
+      tablesPositions.set(table.name, [currentColX, colY]);
+
+      const tableDimension = computeTableDimension(table);
+      const isLastTableInCol = tableIndex + colNumber > tables.length - 1;
+      nextColsY = isLastTableInCol
         ? 0
-        : nextTableX + tableDimension.width + TABLES_GAP_X;
-  });
+        : colY + tableDimension.height + TABLES_GAP_Y;
+
+      currentColMaxW = Math.max(tableDimension.width, currentColMaxW);
+
+      nextTableX = isLastTableInCol
+        ? currentColMaxW + TABLES_GAP_X + currentColX
+        : currentColX;
+      console.log("nextTableX", nextTableX);
+    }
+  }
 
   return tablesPositions;
 };

--- a/packages/json-table-schema-visualizer/src/utils/tablePositioning/tests/computeTablesPositions.test.ts
+++ b/packages/json-table-schema-visualizer/src/utils/tablePositioning/tests/computeTablesPositions.test.ts
@@ -4,7 +4,7 @@ import { getColsNumber } from "../getColsNumber";
 import {
   COLUMN_HEIGHT,
   TABLE_HEADER_HEIGHT,
-  TABLE_WIDTH,
+  TABLE_DEFAULT_MIN_WIDTH,
   TABLES_GAP_X,
   TABLES_GAP_Y,
 } from "@/constants/sizing";
@@ -14,7 +14,7 @@ jest.mock("../getColsNumber", () => ({
   getColsNumber: jest.fn(),
 }));
 
-const TABLE_WIDTH_WITH_GAP = TABLE_WIDTH + TABLES_GAP_X;
+const TABLE_WIDTH_WITH_GAP = TABLE_DEFAULT_MIN_WIDTH + TABLES_GAP_X;
 
 describe("compute tables positions", () => {
   test("less than 6 tables positions", () => {

--- a/packages/json-table-schema-visualizer/src/utils/tableWComputation/computeTablePreferredWidth.ts
+++ b/packages/json-table-schema-visualizer/src/utils/tableWComputation/computeTablePreferredWidth.ts
@@ -1,0 +1,12 @@
+import { computeTextsMaxWidth } from "../computeTextsMaxWidth";
+
+import {
+  TABLE_DEFAULT_MIN_WIDTH,
+  TABLE_FIELD_TYPE_PADDING,
+} from "@/constants/sizing";
+
+export const computeTablePreferredWidth = (tableTexts: string[]): number => {
+  const minW = computeTextsMaxWidth(tableTexts);
+
+  return Math.max(minW + TABLE_FIELD_TYPE_PADDING * 2, TABLE_DEFAULT_MIN_WIDTH);
+};

--- a/packages/json-table-schema-visualizer/src/utils/tableWComputation/getTableLinesText.ts
+++ b/packages/json-table-schema-visualizer/src/utils/tableWComputation/getTableLinesText.ts
@@ -1,0 +1,13 @@
+import { type JSONTableTable } from "shared/types/tableSchema";
+
+export const getTableLinesText = (
+  fields: JSONTableTable["fields"],
+  name: string,
+): string[] => {
+  const stringColsNames = fields.map(
+    (field) => `${field.name} ${field.type.type_name}`,
+  );
+  const tableLinesTexts = [name, ...stringColsNames];
+
+  return tableLinesTexts;
+};

--- a/packages/json-table-schema-visualizer/src/utils/tests/computeTableDimension.test.ts
+++ b/packages/json-table-schema-visualizer/src/utils/tests/computeTableDimension.test.ts
@@ -1,12 +1,15 @@
 import { computeTableDimension } from "../computeTableDimension";
 
 import { exampleData } from "@/fake/fakeJsonTables";
-import { TABLE_HEADER_HEIGHT, TABLE_WIDTH } from "@/constants/sizing";
+import {
+  TABLE_HEADER_HEIGHT,
+  TABLE_DEFAULT_MIN_WIDTH,
+} from "@/constants/sizing";
 
 describe("compute table dimension", () => {
   test("compute table dimension", () => {
     expect(computeTableDimension(exampleData.tables[0])).toEqual({
-      width: TABLE_WIDTH,
+      width: TABLE_DEFAULT_MIN_WIDTH,
       height: TABLE_HEADER_HEIGHT * 5,
     });
   });


### PR DESCRIPTION
This PR make the width of table diagrams adaptive to their content. Before this the table width is fixed.

https://github.com/BOCOVO/db-schema-visualizer/assets/51182814/c8811c60-fdb6-4ad8-92a0-6ba045d464f2

