### PR TITLE
Add support for multiple-file prisma schema

### DIFF
--- a/packages/extension-shared/extension/views/panel.ts
+++ b/packages/extension-shared/extension/views/panel.ts
@@ -80,7 +80,7 @@ export class MainPanel {
 
         if (MainPanel.currentPanel !== undefined) {
           MainPanel.currentPanel._lastTimeout = setTimeout(() => {
-            MainPanel.publishSchema(event.document);
+            void MainPanel.publishSchema(event.document);
           }, DIAGRAM_UPDATER_DEBOUNCE_TIME);
         }
       }
@@ -147,7 +147,7 @@ export class MainPanel {
       MainPanel.registerDiagramUpdaterOnfFileChange();
     }
 
-    MainPanel.publishSchema(editor.document);
+    void MainPanel.publishSchema(editor.document);
   }
 
   static getCurrentEditor(): TextEditor | undefined {
@@ -161,8 +161,36 @@ export class MainPanel {
     return editor;
   }
 
-  static publishSchema = (document: TextDocument): void => {
-    const code = document.getText();
+  static publishSchema = async (document: TextDocument): Promise<void> => {
+    let code = document.getText();
+
+    switch (document.languageId) {
+      // if document is prisma file and the parent folder is "schema" folder, then read all *.prisma files in the folder and merge them.
+      case "prisma": {
+        // Get the parent folder name of the file
+        const folderPath = document.uri.fsPath.split("/");
+        const folderName = folderPath[folderPath.length - 2];
+
+        if (folderName !== "schema") break;
+
+        const schemaFolder = folderPath
+          .slice(0, folderPath.length - 1)
+          .join("/");
+
+        // Get all prisma files in the folder
+        const files = await workspace.findFiles(`**/*.prisma`);
+
+        // Merge all prisma files
+        for (const uri of files) {
+          // Check file in the same folder
+          if (!uri.fsPath.includes(schemaFolder)) continue;
+          const buffer = await workspace.fs.readFile(uri);
+          code += "\n" + buffer.toString();
+        }
+        break;
+      }
+    }
+
     try {
       const schema = MainPanel.parseCode(code);
 


### PR DESCRIPTION
This PR introduces support for split Prisma schemas by automatically merging .prisma files located within the schema directory. This enhancement improves the visualization of schemas in the graph, allowing for a more organized and flexible schema structure.

**Changes Made:**

**Auto-Merging Functionality:** Added logic to publishSchema in packages/extension-shared/extension/views/panel.ts to check for .prisma files within the schema directory and merge them if found.
**Async Method Update:** Converted publishSchema to an async method to utilize workspace.findFiles and workspace.fs.readFile for file operations.
**Type Adjustment:** Added void to the call of MainPanel.publishSchema to prevent compilation errors without affecting existing functionality.

**Impact:**

**No Regression:** The changes do not affect current functionality.
**Improved Support:** Enables proper handling of split schema files, enhancing the user experience for those organizing schemas in multiple files within the schema directory.

**Testing:**

The changes have been tested to ensure correct merging and display of split schemas. Further testing is welcome to confirm functionality across different setups.

**Conclusion:**

This PR enhances the Prisma schema handling, offering better support for split schemas. I appreciate your consideration and look forward to your feedback.

Thank you for your attention, and I hope this improvement can be included in an upcoming release.

Best regards,

Togo01