### PR TITLE
Add 'Fit To View' functionality to toolbar

### DIFF
--- a/packages/json-table-schema-visualizer/src/components/DiagramViewer/DiagramWrapper.tsx
+++ b/packages/json-table-schema-visualizer/src/components/DiagramViewer/DiagramWrapper.tsx
@@ -73,6 +73,40 @@ const DiagramWrapper = ({ children }: DiagramWrapperProps) => {
     stageStateStore.set({ scale: newScale, position: newPos });
   };
 
+  const fitToView = () => {
+    if (stageRef.current != null) {
+      const stage = stageRef.current;
+      const container = stage.container();
+      const containerWidth = container.offsetWidth;
+      const containerHeight = container.offsetHeight;
+
+      const contentBounds = stage.getClientRect({ relativeTo: stage });
+      contentBounds.x = contentBounds.x - DIAGRAM_PADDING;
+      contentBounds.y = contentBounds.y - DIAGRAM_PADDING;
+      contentBounds.width = contentBounds.width + 2 * DIAGRAM_PADDING;
+      contentBounds.height = contentBounds.height + 2 * DIAGRAM_PADDING;
+      const scaleX = containerWidth / contentBounds.width;
+      const scaleY = containerHeight / contentBounds.height;
+      const scale = Math.min(scaleX, scaleY);
+
+      stage.scale({ x: scale, y: scale });
+      stage.position({
+        x:
+          (containerWidth - contentBounds.width * scale) / 2 -
+          contentBounds.x * scale,
+        y:
+          (containerHeight - contentBounds.height * scale) / 2 -
+          contentBounds.y * scale,
+      });
+      stage.batchDraw();
+      stageStateStore.set({ scale, position: stage.position() });
+    }
+  };
+
+  useEffect(() => {
+    fitToView();
+  }, [windowWidth, windowHeight]);
+
   return (
     <main
       className={`relative flex flex-col items-center ${theme === Theme.dark ? "dark" : ""}`}
@@ -94,7 +128,7 @@ const DiagramWrapper = ({ children }: DiagramWrapperProps) => {
         </Layer>
       </Stage>
 
-      <Toolbar />
+      <Toolbar onFitToView={fitToView} />
     </main>
   );
 };

--- a/packages/json-table-schema-visualizer/src/components/DiagramViewer/DiagramWrapper.tsx
+++ b/packages/json-table-schema-visualizer/src/components/DiagramViewer/DiagramWrapper.tsx
@@ -103,10 +103,6 @@ const DiagramWrapper = ({ children }: DiagramWrapperProps) => {
     }
   };
 
-  useEffect(() => {
-    fitToView();
-  }, [windowWidth, windowHeight]);
-
   return (
     <main
       className={`relative flex flex-col items-center ${theme === Theme.dark ? "dark" : ""}`}

--- a/packages/json-table-schema-visualizer/src/components/Toolbar/FitToView/FitToView.tsx
+++ b/packages/json-table-schema-visualizer/src/components/Toolbar/FitToView/FitToView.tsx
@@ -1,0 +1,22 @@
+import { ExpandIcon } from "lucide-react";
+import PropTypes from "prop-types";
+
+import ToolbarButton from "../Button";
+
+interface FitToViewButtonProps {
+  onClick: () => void;
+}
+
+const FitToViewButton: React.FC<FitToViewButtonProps> = ({ onClick }) => {
+  return (
+    <ToolbarButton onClick={onClick} title="Fit-to-view">
+      <ExpandIcon />
+      <span className="ml-2">Fit To View</span>
+    </ToolbarButton>
+  );
+};
+FitToViewButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+};
+
+export default FitToViewButton;

--- a/packages/json-table-schema-visualizer/src/components/Toolbar/FitToView/FitToView.tsx
+++ b/packages/json-table-schema-visualizer/src/components/Toolbar/FitToView/FitToView.tsx
@@ -1,5 +1,4 @@
 import { ExpandIcon } from "lucide-react";
-import PropTypes from "prop-types";
 
 import ToolbarButton from "../Button";
 
@@ -7,16 +6,13 @@ interface FitToViewButtonProps {
   onClick: () => void;
 }
 
-const FitToViewButton: React.FC<FitToViewButtonProps> = ({ onClick }) => {
+const FitToViewButton = ({ onClick } : FitToViewButtonProps) => {
   return (
     <ToolbarButton onClick={onClick} title="Fit-to-view">
       <ExpandIcon />
       <span className="ml-2">Fit To View</span>
     </ToolbarButton>
   );
-};
-FitToViewButton.propTypes = {
-  onClick: PropTypes.func.isRequired,
 };
 
 export default FitToViewButton;

--- a/packages/json-table-schema-visualizer/src/components/Toolbar/Toolbar.tsx
+++ b/packages/json-table-schema-visualizer/src/components/Toolbar/Toolbar.tsx
@@ -1,17 +1,24 @@
+import PropTypes from "prop-types";
+
 import AutoArrangeTableButton from "./AutoArrage/AutoArrangeTables";
 import ThemeToggler from "./ThemeToggler/ThemeToggler";
 import DetailLevelToggle from "./DetailLevelToggle/DetailLevelToggle";
+import FitToViewButton from "./FitToView/FitToView";
 
-const Toolbar = () => {
+const Toolbar = ({ onFitToView }: { onFitToView: () => void }) => {
   return (
     <div className="flex absolute [&_svg]:w-5 [&_svg]:h-5 px-6 py-1 bottom-14 text-sm bg-gray-100 dark:bg-gray-700 shadow-lg rounded-2xl">
       <AutoArrangeTableButton />
       <DetailLevelToggle />
+      <FitToViewButton onClick={onFitToView} />
       <hr className="w-px h-6 mx-4 my-1 bg-gray-300" />
-
       <ThemeToggler />
     </div>
   );
+};
+
+Toolbar.propTypes = {
+  onFitToView: PropTypes.func.isRequired,
 };
 
 export default Toolbar;


### PR DESCRIPTION
This pull request introduces a new "Fit To View" feature in the toolbar. The functionality allows users to automatically adjust the zoom and positioning of tables with a single click, ensuring all content is fully visible within the viewport. This enhancement improves user experience by simplifying the process of adjusting views after manual zooming or repositioning.

**Changes Made:**

1. Added a new component `FitToView.tsx` in `/packages/json-table-schema-visualizer/src/components/Toolbar/FitToView/` to handle the "Fit To View" functionality.
2. Updated `Toolbar.tsx` to include the new "Fit To View" button.
3. Modified `DiagramWrapper.tsx` to add the fitToView method, which handles the logic for adjusting the view.

**Testing Steps:**

1. Open a table or schema visualization.
2. Manually zoom in/out or reposition the content.
3. Click the "Fit To View" button in the toolbar.
4. Verify that the content is automatically adjusted to fit within the viewport.

Notes:

This feature provides a convenient way to reset the view without manual adjustments, making it easier for users to navigate and work with the visualization.