### PR TITLE
[codex] Support PostgreSQL index types in DBML parser

### DIFF
--- a/packages/dbml-to-json-table-schema/src/index.test.ts
+++ b/packages/dbml-to-json-table-schema/src/index.test.ts
@@ -1,0 +1,45 @@
+import { parseDBMLToJSON } from ".";
+
+describe("parse DBML to JSON", () => {
+  test("parses PostGIS gist indexes", () => {
+    const schema = parseDBMLToJSON(`
+      Table parcel {
+        id integer [primary key]
+        geom_lv95 geometry
+
+        indexes {
+          geom_lv95 [type: gist]
+        }
+      }
+    `);
+
+    expect(schema.tables[0].indexes[0]).toEqual({
+      columns: [{ type: "column", value: "geom_lv95" }],
+      name: undefined,
+      note: undefined,
+      pk: false,
+      type: "gist",
+      unique: undefined,
+    });
+  });
+
+  test("keeps existing hash indexes when restoring unsupported index types", () => {
+    const schema = parseDBMLToJSON(`
+      Table parcel {
+        id integer [primary key]
+        code varchar
+        geom_lv95 geometry
+
+        indexes {
+          code [type: hash]
+          geom_lv95 [type: gist]
+        }
+      }
+    `);
+
+    expect(schema.tables[0].indexes.map((index) => index.type)).toEqual([
+      "hash",
+      "gist",
+    ]);
+  });
+});

--- a/packages/dbml-to-json-table-schema/src/index.ts
+++ b/packages/dbml-to-json-table-schema/src/index.ts
@@ -1,6 +1,7 @@
 import { Parser, type CompilerDiagnostic } from "@dbml/core";
 import { DiagnosticError } from "shared/types/diagnostic";
 
+import { normalizePostgresIndexTypesForDBMLParser } from "./utils/normalizePostgresIndexTypes";
 import { dbmlSchemaToJSONTableSchema } from "./utils/transfomers/dbmlSchemaToJSONTableSchema";
 import { validateSchema } from "./validators";
 
@@ -8,7 +9,10 @@ import type { JSONTableSchema } from "shared/types/tableSchema";
 
 export const parseDBMLToJSON = (dbmlCode: string): JSONTableSchema => {
   try {
-    const rawParsedSchema = Parser.parseDBMLToJSON(dbmlCode);
+    const parserInput = normalizePostgresIndexTypesForDBMLParser(dbmlCode);
+    const rawParsedSchema = Parser.parseDBMLToJSON(parserInput.dbmlCode);
+
+    parserInput.restoreIndexTypes(rawParsedSchema);
     validateSchema(rawParsedSchema);
     return dbmlSchemaToJSONTableSchema(rawParsedSchema);
   } catch (error) {

--- a/packages/dbml-to-json-table-schema/src/utils/normalizePostgresIndexTypes.test.ts
+++ b/packages/dbml-to-json-table-schema/src/utils/normalizePostgresIndexTypes.test.ts
@@ -1,0 +1,79 @@
+import { normalizePostgresIndexTypesForDBMLParser } from "./normalizePostgresIndexTypes";
+
+describe("normalize postgres index types for dbml parser", () => {
+  test("normalizes unsupported postgres index types for the DBML parser", () => {
+    const result = normalizePostgresIndexTypesForDBMLParser(`
+      Table parcel {
+        geom_lv95 geometry
+
+        indexes {
+          geom_lv95 [type: GiST]
+          (geom_lv95) [name: 'geom_idx', type: gin]
+        }
+      }
+    `);
+
+    expect(result.dbmlCode).toContain("geom_lv95 [type: hash");
+    expect(result.dbmlCode).toContain(
+      "(geom_lv95) [name: 'geom_idx', type: hash",
+    );
+  });
+
+  test("does not normalize text outside index blocks", () => {
+    const dbmlCode = `
+      Table parcel {
+        id integer [note: '[type: gist]']
+        geom_lv95 geometry
+
+        indexes {
+          geom_lv95 [type: gist]
+        }
+      }
+    `;
+
+    const result = normalizePostgresIndexTypesForDBMLParser(dbmlCode);
+
+    expect(result.dbmlCode).toContain("id integer [note: '[type: gist]']");
+    expect(result.dbmlCode).toContain("geom_lv95 [type: hash");
+  });
+
+  test("restores normalized types by parsed index order", () => {
+    const result = normalizePostgresIndexTypesForDBMLParser(`
+      Table parcel {
+        code varchar
+        geom_lv95 geometry
+
+        indexes {
+          code [type: hash]
+          geom_lv95 [type: gist]
+        }
+      }
+
+      Table boundary {
+        geom geometry
+
+        indexes {
+          geom [type: brin]
+        }
+      }
+    `);
+
+    const rawParsedSchema = {
+      tables: [
+        {
+          indexes: [{ type: "hash" }, { type: "hash" }],
+        },
+        {
+          indexes: [{ type: "hash" }],
+        },
+      ],
+    };
+
+    result.restoreIndexTypes(rawParsedSchema);
+
+    expect(rawParsedSchema.tables.map((table) => table.indexes)).toEqual([
+      [{ type: "hash" }, { type: "gist" }],
+      [{ type: "brin" }],
+    ]);
+  });
+});

--- a/packages/dbml-to-json-table-schema/src/utils/normalizePostgresIndexTypes.ts
+++ b/packages/dbml-to-json-table-schema/src/utils/normalizePostgresIndexTypes.ts
@@ -1,0 +1,264 @@
+const DBML_SUPPORTED_INDEX_TYPE = "hash";
+const POSTGRES_INDEX_TYPES = new Set(["brin", "gin", "gist", "spgist"]);
+const INDEX_TYPE_SETTING_REGEX =
+  /(\[\s*|,\s*)type\s*:\s*([A-Za-z][A-Za-z0-9_]*)\b/;
+
+interface UnsupportedIndexTypeReplacement {
+  indexNumber: number;
+  type: string;
+}
+
+interface IndexBlockRange {
+  content: string;
+  contentEndIndex: number;
+  contentStartIndex: number;
+}
+
+interface DBMLIndex {
+  type?: string;
+}
+
+interface DBMLTableWithIndexes {
+  indexes: DBMLIndex[];
+}
+
+interface DBMLSchemaWithIndexes {
+  tables: DBMLTableWithIndexes[];
+}
+
+interface NormalizedDBMLForParser {
+  dbmlCode: string;
+  restoreIndexTypes: (rawParsedSchema: DBMLSchemaWithIndexes) => void;
+}
+
+const stripDBMLComments = (value: string): string =>
+  value.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+
+const findClosingBraceIndex = (
+  value: string,
+  openingBraceIndex: number,
+): number => {
+  let depth = 0;
+  let quote: string | null = null;
+
+  for (let index = openingBraceIndex; index < value.length; index += 1) {
+    const char = value[index];
+    const previousChar = value[index - 1];
+
+    if (quote !== null) {
+      if (char === quote && previousChar !== "\\") {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      depth -= 1;
+
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return -1;
+};
+
+const getIndexBlockRanges = (dbmlCode: string): IndexBlockRange[] => {
+  const indexBlockRanges: IndexBlockRange[] = [];
+  const indexesBlockRegex = /\bindexes\s*\{/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = indexesBlockRegex.exec(dbmlCode)) !== null) {
+    const openingBraceIndex = dbmlCode.indexOf("{", match.index);
+    const closingBraceIndex = findClosingBraceIndex(
+      dbmlCode,
+      openingBraceIndex,
+    );
+
+    if (closingBraceIndex === -1) {
+      continue;
+    }
+
+    indexBlockRanges.push({
+      content: dbmlCode.slice(openingBraceIndex + 1, closingBraceIndex),
+      contentEndIndex: closingBraceIndex,
+      contentStartIndex: openingBraceIndex + 1,
+    });
+    indexesBlockRegex.lastIndex = closingBraceIndex + 1;
+  }
+
+  return indexBlockRanges;
+};
+
+const splitIndexBlockEntries = (indexBlockContent: string): string[] => {
+  const entries: string[] = [];
+  let entryStartIndex = 0;
+  let bracketDepth = 0;
+  let parenthesisDepth = 0;
+  let quote: string | null = null;
+
+  for (let index = 0; index < indexBlockContent.length; index += 1) {
+    const char = indexBlockContent[index];
+    const previousChar = indexBlockContent[index - 1];
+
+    if (quote !== null) {
+      if (char === quote && previousChar !== "\\") {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "[") {
+      bracketDepth += 1;
+      continue;
+    }
+
+    if (char === "]") {
+      bracketDepth -= 1;
+      continue;
+    }
+
+    if (char === "(") {
+      parenthesisDepth += 1;
+      continue;
+    }
+
+    if (char === ")") {
+      parenthesisDepth -= 1;
+      continue;
+    }
+
+    if (char === "\n" && bracketDepth === 0 && parenthesisDepth === 0) {
+      entries.push(indexBlockContent.slice(entryStartIndex, index));
+      entryStartIndex = index + 1;
+    }
+  }
+
+  entries.push(indexBlockContent.slice(entryStartIndex));
+
+  return entries.filter((entry) => stripDBMLComments(entry).trim() !== "");
+};
+
+const collectUnsupportedIndexTypeReplacements = (
+  dbmlCode: string,
+): UnsupportedIndexTypeReplacement[] => {
+  const replacements: UnsupportedIndexTypeReplacement[] = [];
+  let indexNumber = 0;
+
+  for (const { content: indexBlockContent } of getIndexBlockRanges(dbmlCode)) {
+    for (const entry of splitIndexBlockEntries(indexBlockContent)) {
+      const indexType = stripDBMLComments(entry).match(
+        INDEX_TYPE_SETTING_REGEX,
+      )?.[2];
+      const normalizedIndexType = indexType?.toLowerCase();
+
+      if (
+        normalizedIndexType !== undefined &&
+        POSTGRES_INDEX_TYPES.has(normalizedIndexType)
+      ) {
+        replacements.push({
+          indexNumber,
+          type: normalizedIndexType,
+        });
+      }
+
+      indexNumber += 1;
+    }
+  }
+
+  return replacements;
+};
+
+const normalizeUnsupportedIndexTypesForDBMLParser = (
+  dbmlCode: string,
+): string => {
+  const indexBlockRanges = getIndexBlockRanges(dbmlCode);
+
+  if (indexBlockRanges.length === 0) {
+    return dbmlCode;
+  }
+
+  let normalizedDBMLCode = "";
+  let previousIndex = 0;
+
+  for (const indexBlockRange of indexBlockRanges) {
+    normalizedDBMLCode += dbmlCode.slice(
+      previousIndex,
+      indexBlockRange.contentStartIndex,
+    );
+    normalizedDBMLCode += indexBlockRange.content.replace(
+      /(\[\s*|,\s*)type\s*:\s*(brin|gin|gist|spgist)\b/gi,
+      (match: string, settingPrefix: string) => {
+        const replacement = `${settingPrefix}type: ${DBML_SUPPORTED_INDEX_TYPE}`;
+        return `${replacement}${" ".repeat(
+          Math.max(0, match.length - replacement.length),
+        )}`;
+      },
+    );
+    previousIndex = indexBlockRange.contentEndIndex;
+  }
+
+  return `${normalizedDBMLCode}${dbmlCode.slice(previousIndex)}`;
+};
+
+const restoreUnsupportedIndexTypes = (
+  rawParsedSchema: DBMLSchemaWithIndexes,
+  replacements: UnsupportedIndexTypeReplacement[],
+): void => {
+  if (replacements.length === 0) {
+    return;
+  }
+
+  const replacementsByIndexNumber = new Map(
+    replacements.map((replacement) => [
+      replacement.indexNumber,
+      replacement.type,
+    ]),
+  );
+  let indexNumber = 0;
+
+  for (const table of rawParsedSchema.tables) {
+    for (const index of table.indexes) {
+      const replacement = replacementsByIndexNumber.get(indexNumber);
+
+      if (replacement !== undefined) {
+        index.type = replacement;
+      }
+
+      indexNumber += 1;
+    }
+  }
+};
+
+export const normalizePostgresIndexTypesForDBMLParser = (
+  dbmlCode: string,
+): NormalizedDBMLForParser => {
+  const unsupportedIndexTypeReplacements =
+    collectUnsupportedIndexTypeReplacements(dbmlCode);
+
+  return {
+    dbmlCode: normalizeUnsupportedIndexTypesForDBMLParser(dbmlCode),
+    restoreIndexTypes: (rawParsedSchema) => {
+      restoreUnsupportedIndexTypes(
+        rawParsedSchema,
+        unsupportedIndexTypeReplacements,
+      );
+    },
+  };
+};


### PR DESCRIPTION
## Summary

Adds a compatibility layer for DBML indexes that use PostgreSQL index methods currently rejected by `@dbml/core`, such as `gist`, `gin`, `brin`, and `spgist`.

## Details

`@dbml/core` rejects DBML index settings like `geom_lv95 [type: gist]` before this package can transform the parsed schema. The parser currently accepts only `btree` and `hash`; this behavior is still present in `@dbml/core@8.2.5`.

This change normalizes unsupported PostgreSQL index methods to a parser-supported type only inside `indexes { ... }` blocks, parses the schema, then restores the original index methods on the parsed indexes before validation and transformation.

## Validation

- `corepack yarn workspace dbml-to-json-table-schema test --runInBand`
- Pre-commit hook: `lint-staged`, including `tsc-files --noEmit`, `eslint --fix`, and `prettier --write`

## Notes

A true upstream fix would be to extend the `@dbml/core` DBML grammar to accept these PostgreSQL index methods directly. Until then, this keeps the workaround local and narrowly scoped.
